### PR TITLE
gc: bump submodule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         # This command requires push access to ghcr.io/coco-serverless
         run: ./bin/inv_wrapper.sh knative.install
       - name: "Update the Kata agent"
-        run: ./bin/inv_wrapper.sh kata.build kata.replace-agent
+        run: ./bin/inv_wrapper.sh kata.build --nocache kata.replace-agent
       - name: "Run python hello world"
         run: |
           ./bin/kubectl apply -f ./apps/helloworld-py

--- a/bin/workon.sh
+++ b/bin/workon.sh
@@ -12,9 +12,6 @@ if [ ! -d "venv" ]; then
 fi
 source venv/bin/activate
 
-# Update submodules
-git submodule update --init
-
 # Invoke tab-completion
 _complete_invoke() {
     local candidates

--- a/docker/kata.dockerfile
+++ b/docker/kata.dockerfile
@@ -1,4 +1,4 @@
-FROM csegarragonz/dotfiles:0.2.0 as dotfiles
+FROM csegarragonz/dotfiles:0.2.0 AS dotfiles
 FROM ubuntu:22.04
 
 # ---------------------------
@@ -51,9 +51,10 @@ RUN apt install -y \
         wget
 
 # Install latest rust and rust-analyser
+ARG RUST_ANALYZER_VERSION="2024-09-02"
 RUN curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | sh -s -- -y \
     && curl -L \
-        https://github.com/rust-lang/rust-analyzer/releases/latest/download/rust-analyzer-x86_64-unknown-linux-gnu.gz \
+        https://github.com/rust-lang/rust-analyzer/releases/download/${RUST_ANALYZER_VERSION}/rust-analyzer-x86_64-unknown-linux-gnu.gz \
         | gunzip -c - > /usr/bin/rust-analyzer \
     && chmod +x /usr/bin/rust-analyzer
 

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -33,11 +33,28 @@ inv kata.cli
 Replacing the Kata Agent is something we may do regularly, and is a fairly
 automated process.
 
-First, enter the Kata CLI, make changes to the `kata-agent` binary, and re-build
-it:
+The agent replacement script copies the agent binary from our Kata work-on
+docker image. There are two ways in which the copying happens:
+
+### One-off Copy
+
+If the work-on image is not running, the script will copy the built-in binary
+from the built-in image. The steps are:
+
+```bash
+inv kata.build
+inv kata.replace-agent
+```
+
+### Hot-Patch
+
+To develop on Kata, and quickly generate new `initrd`s, you may use the Kata
+CLI. In this case, when the work-on image is running, the replacement script
+will copy the binary from the CLI. Note that, as previously mentioned,
+any changes made therein are not persisted across container restarts.
 
 ```bas
-inv kata.cli
+inv kata.cli [--mount-path <path_to_local_kata_checkout>]
 cd src/agent
 ...
 # Make changes

--- a/tasks/kata.py
+++ b/tasks/kata.py
@@ -35,11 +35,11 @@ def build(ctx, nocache=False):
 
 
 @task
-def cli(ctx):
+def cli(ctx, mount_path=None):
     """
     Get a working environemnt to develop Kata
     """
-    run_kata_workon_ctr()
+    run_kata_workon_ctr(mount_path=mount_path)
     run("docker exec -it {} bash".format(KATA_WORKON_CTR_NAME), shell=True, check=True)
 
 

--- a/tasks/util/kata.py
+++ b/tasks/util/kata.py
@@ -16,7 +16,7 @@ KATA_SOURCE_DIR = "/go/src/github.com/kata-containers/kata-containers"
 KATA_AGENT_SOURCE_DIR = join(KATA_SOURCE_DIR, "src", "agent")
 
 
-def run_kata_workon_ctr():
+def run_kata_workon_ctr(mount_path=None):
     """
     Start Kata workon container image if it is not running. Return `True` if
     we actually did start the container
@@ -27,6 +27,11 @@ def run_kata_workon_ctr():
     docker_cmd = [
         "docker run",
         "-d -t",
+        (
+            f"-v {mount_path}:/go/src/github.com/kata-containers/kata-containers"
+            if mount_path
+            else ""
+        ),
         "--name {}".format(KATA_WORKON_CTR_NAME),
         KATA_WORKON_IMAGE_TAG,
         "bash",


### PR DESCRIPTION
In this PR we bump the GC submodule to point to our own fork, and clarify the instructions to replace the Kata Agent. We also add a flag to mount our local Kata checkout when starting the Kata CLI.